### PR TITLE
feat: declare AMQP exchange and queue at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WhatsMeow Adapter (Provider UNOAPI Cloud)
 
 Microserviço **Go** que:
-- consome mensagens **AMQP/RabbitMQ** (rota `provider.whatsmeow.*`);
+- consome mensagens **AMQP/RabbitMQ** (rota `provider.whatsmeow.*`, fila `provider.whatsmeow` criada automaticamente);
 - envia via **WhatsMeow** (WhatsApp MD);
 - publica **webhooks** (Cloud-like) se `WEBHOOK_BASE` estiver definido;
 - expõe HTTP para gerenciar sessões e health checks.

--- a/cmd/whatsmeow-adapter/main.go
+++ b/cmd/whatsmeow-adapter/main.go
@@ -30,10 +30,15 @@ func main() {
 	// message consumer.
 	clientManager := provider.NewClientManager(cfg.SessionStore, cfg.WebhookBase)
 
+	// Ensure the exchange and durable queue exist so that publishers can
+	// send messages even if the adapter is temporarily offline.
+	if err := amqpconsumer.InitExchange(cfg); err != nil {
+		log.Fatalf("failed to initialize AMQP exchange: %v", err)
+	}
+
 	// Initialize the AMQP consumer.  The consumer will connect to the
-	// broker, bind a temporary queue to the configured exchange and
-	// routing key and then dispatch all incoming messages to the
-	// provider send function.
+	// broker, bind the configured queue to the exchange and routing key and
+	// then dispatch all incoming messages to the provider send function.
 	consumer, err := amqpconsumer.NewConsumer(cfg, clientManager)
 	if err != nil {
 		log.Fatalf("failed to initialise AMQP consumer: %v", err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       AMQP_URL: "${AMQP_URL}"
       AMQP_EXCHANGE: "${AMQP_EXCHANGE:-unoapi.outgoing}"
       AMQP_BINDING: "${AMQP_BINDING:-provider.whatsmeow.*}"
+      AMQP_QUEUE: "${AMQP_QUEUE:-provider.whatsmeow}"
       WEBHOOK_BASE: "${WEBHOOK_BASE:-}"       # opcional
       SESSION_STORE: "/var/lib/whatsmeow"
       HTTP_ADDR: ":8080"

--- a/internal/amqp/consumer.go
+++ b/internal/amqp/consumer.go
@@ -80,10 +80,10 @@ func (c *Consumer) Start(ctx context.Context) error {
 	}
 
 	queue, err := ch.QueueDeclare(
-		"",
+		c.cfg.AMQPQueue,
 		true,  // durable
 		false, // autoDelete
-		true,  // exclusive
+		false, // exclusive
 		false, // noWait
 		nil,
 	)
@@ -93,7 +93,7 @@ func (c *Consumer) Start(ctx context.Context) error {
 	c.queue = queue
 
 	if err := ch.QueueBind(
-		queue.Name,
+		c.cfg.AMQPQueue,
 		c.cfg.AMQPBinding,
 		c.cfg.AMQPExchange,
 		false,
@@ -103,7 +103,7 @@ func (c *Consumer) Start(ctx context.Context) error {
 	}
 
 	deliveries, err := ch.Consume(
-		queue.Name,
+		c.cfg.AMQPQueue,
 		"",
 		true,  // auto-ack
 		false, // exclusive

--- a/internal/amqp/init.go
+++ b/internal/amqp/init.go
@@ -1,0 +1,67 @@
+package amqp
+
+import (
+	"fmt"
+	"log"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"your.org/provider-whatsmeow/internal/config"
+)
+
+// InitExchange declares the exchange and queue consumed by this service.
+// It is safe to call multiple times as declarations are idempotent.
+func InitExchange(cfg *config.Config) error {
+	if cfg.AMQPURL == "" {
+		log.Println("AMQP URL is empty; skipping exchange initialization")
+		return nil
+	}
+
+	conn, err := amqp.Dial(cfg.AMQPURL)
+	if err != nil {
+		return fmt.Errorf("failed to dial AMQP: %w", err)
+	}
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	if err != nil {
+		return fmt.Errorf("failed to open channel: %w", err)
+	}
+	defer ch.Close()
+
+	if err := ch.ExchangeDeclare(
+		cfg.AMQPExchange,
+		"topic",
+		true,
+		false,
+		false,
+		false,
+		nil,
+	); err != nil {
+		return fmt.Errorf("failed to declare exchange: %w", err)
+	}
+
+	if cfg.AMQPQueue != "" {
+		if _, err := ch.QueueDeclare(
+			cfg.AMQPQueue,
+			true,
+			false,
+			false,
+			false,
+			nil,
+		); err != nil {
+			return fmt.Errorf("failed to declare queue: %w", err)
+		}
+
+		if err := ch.QueueBind(
+			cfg.AMQPQueue,
+			cfg.AMQPBinding,
+			cfg.AMQPExchange,
+			false,
+			nil,
+		); err != nil {
+			return fmt.Errorf("failed to bind queue: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,10 @@ type Config struct {
 	// queue.  It is set to "provider.whatsmeow.*" to receive all
 	// messages destined for this provider.
 	AMQPBinding string
+	// AMQPQueue is the name of the queue that will be declared and
+	// consumed by this service.  If empty, a server-generated name is
+	// used.
+	AMQPQueue string
 	// WebhookBase is the base URL to which webhook payloads should be
 	// delivered.  If left empty the service will not emit webhooks.
 	WebhookBase string
@@ -37,6 +41,7 @@ func NewConfig() *Config {
 	cfg.AMQPURL = getEnv("AMQP_URL", "amqp://user_test:123456@localhost:5672/EnvolveNEXT")
 	cfg.AMQPExchange = getEnv("AMQP_EXCHANGE", "unoapi.outgoing")
 	cfg.AMQPBinding = getEnv("AMQP_BINDING", "provider.whatsmeow.*")
+	cfg.AMQPQueue = getEnv("AMQP_QUEUE", "provider.whatsmeow")
 	cfg.WebhookBase = getEnv("WEBHOOK_BASE", "https://localhost/webhooks/whatsapp")
 	cfg.SessionStore = getEnv("SESSION_STORE", "./state/whatsmeow")
 	cfg.HTTPAddr = getEnv("HTTP_ADDR", ":8080")

--- a/internal/provider/send.go
+++ b/internal/provider/send.go
@@ -73,6 +73,13 @@ type OutgoingMessage struct {
 	Mentions         []string         `json:"mentions,omitempty"`
 }
 
+func sendWithID(ctx context.Context, cli *whatsmeow.Client, jid types.JID, msg *goE2E.Message, id string) (whatsmeow.SendResponse, error) {
+	if strings.TrimSpace(id) != "" {
+		return cli.SendMessage(ctx, jid, msg, whatsmeow.SendRequestExtra{ID: types.MessageID(id)})
+	}
+	return cli.SendMessage(ctx, jid, msg)
+}
+
 // Send envia a mensagem; sessão vem do contexto (routing key) ou do payload.
 func (m *ClientManager) Send(ctx context.Context, msg OutgoingMessage) error {
 	sessionID := strings.TrimSpace(msg.SessionID)
@@ -170,7 +177,7 @@ func (m *ClientManager) Send(ctx context.Context, msg OutgoingMessage) error {
 		} else {
 			wire = &goE2E.Message{Conversation: proto.String(body)}
 		}
-		resp, err := cli.SendMessage(ctx, jid, wire)
+		resp, err := sendWithID(ctx, cli, jid, wire, msg.MessageID)
 		if err != nil {
 			entry.Error("send text failed: %v", err)
 			return err
@@ -217,7 +224,7 @@ func (m *ClientManager) Send(ctx context.Context, msg OutgoingMessage) error {
 		if ctxInfo != nil {
 			imgMsg.ContextInfo = ctxInfo
 		}
-		resp, err := cli.SendMessage(ctx, jid, &goE2E.Message{ImageMessage: imgMsg})
+		resp, err := sendWithID(ctx, cli, jid, &goE2E.Message{ImageMessage: imgMsg}, msg.MessageID)
 		if err != nil {
 			entry.Error("send image failed: %v", err)
 			return err
@@ -270,7 +277,7 @@ func (m *ClientManager) Send(ctx context.Context, msg OutgoingMessage) error {
 		if ctxInfo != nil {
 			docMsg.ContextInfo = ctxInfo
 		}
-		resp, err := cli.SendMessage(ctx, jid, &goE2E.Message{DocumentMessage: docMsg})
+		resp, err := sendWithID(ctx, cli, jid, &goE2E.Message{DocumentMessage: docMsg}, msg.MessageID)
 		if err != nil {
 			entry.Error("send document failed: %v", err)
 			return err
@@ -335,7 +342,7 @@ func (m *ClientManager) Send(ctx context.Context, msg OutgoingMessage) error {
 			audioMsg.Waveform = wf
 		}
 
-		resp, err := cli.SendMessage(ctx, jid, &goE2E.Message{AudioMessage: audioMsg})
+		resp, err := sendWithID(ctx, cli, jid, &goE2E.Message{AudioMessage: audioMsg}, msg.MessageID)
 		if err != nil {
 			entry.Error("send audio failed: %v", err)
 			return err
@@ -375,7 +382,7 @@ func (m *ClientManager) Send(ctx context.Context, msg OutgoingMessage) error {
 		if ctxInfo != nil {
 			stickerMsg.ContextInfo = ctxInfo
 		}
-		resp, err := cli.SendMessage(ctx, jid, &goE2E.Message{StickerMessage: stickerMsg})
+		resp, err := sendWithID(ctx, cli, jid, &goE2E.Message{StickerMessage: stickerMsg}, msg.MessageID)
 		if err != nil {
 			entry.Error("send sticker failed: %v", err)
 			return err


### PR DESCRIPTION
## Summary
- declare exchange/queue via new `InitExchange` helper
- consume from persistent AMQP queue using `AMQP_QUEUE`
- document AMQP queue and expose env config
- preserve message IDs when sending via WhatsMeow for status tracking

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bdf8b9017483249a640464b92640c1