### PR TITLE
Include sticker filename in UNO payload

### DIFF
--- a/internal/provider/events.go
+++ b/internal/provider/events.go
@@ -177,8 +177,11 @@ func (m *ClientManager) emitCloudMessage(sessionID string, client *whatsmeow.Cli
 		s := msg.GetStickerMessage()
 		wireMsg["type"] = "sticker"
 		mimeType := s.GetMimetype()
-		objName := mediaKey(phone, e.Info.ID) + extensionByMime(mimeType)
+		ext := extensionByMime(mimeType)
+		objName := mediaKey(phone, e.Info.ID) + ext
+		filename := e.Info.ID + ext
 		sticker := map[string]any{
+			"filename":  filename,
 			"mime_type": splitMime(mimeType),
 			"sha256":    b64(s.GetFileSHA256()),
 			"id":        e.Info.ID,


### PR DESCRIPTION
## Summary
- ensure sticker messages include a filename when forwarded via UNO payload

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bf974422e48324b89a4aca7fb89905